### PR TITLE
Enable volume remove functionality

### DIFF
--- a/tests/docker/volume_purge
+++ b/tests/docker/volume_purge
@@ -1,0 +1,131 @@
+{
+    "context": {
+        "logicName": "VolumeStoragePoolMapRemove",
+        "logicPath": "volume.purge->(VolumePurge)->volume.deallocate->(VolumeDeallocate)->volumestoragepoolmap.remove->(VolumeStoragePoolMapRemove)",
+        "prettyProcess": "volume.purge->volumestoragepoolmap.remove",
+        "prettyResource": "volume:9->volumeStoragePoolMap:9",
+        "processId": "88",
+        "processName": "volumestoragepoolmap.remove",
+        "processUuid": "421099cb-64fb-4bc5-8377-7b281f2336c1",
+        "resouceId": "9",
+        "resouceType": "volumeStoragePoolMap",
+        "topProcessName": "volume.purge",
+        "topResourceId": "9",
+        "topResourceType": "volume"
+    },
+    "data": {
+        "volumeStoragePoolMap": {
+            "created": 1417563256000,
+            "data": {
+                "fields": {}
+            },
+            "description": null,
+            "id": 9,
+            "kind": "volumeStoragePoolMap",
+            "name": null,
+            "removeTime": null,
+            "removed": null,
+            "state": "removing",
+            "storagePool": {
+                "accountId": 1,
+                "agentId": 1,
+                "created": 1417562939000,
+                "data": {
+                    "fields": {
+                        "hostUuid": "7194b88c-b651-4884-942b-e0352c280e30",
+                        "type": "storagePool"
+                    }
+                },
+                "description": null,
+                "external": false,
+                "id": 1,
+                "kind": "docker",
+                "name": "boot2docker Storage Pool",
+                "physicalTotalSizeMb": null,
+                "removeTime": null,
+                "removed": null,
+                "state": "active",
+                "type": "storagePool",
+                "uuid": "7194b88c-b651-4884-942b-e0352c280e30-pool",
+                "virtualTotalSizeMb": null,
+                "zoneId": 1
+            },
+            "storagePoolId": 1,
+            "type": "volumeStoragePoolMap",
+            "uuid": "e44ad6aa-7f73-4388-8936-26d05bee4324",
+            "volume": {
+                "accountId": 1,
+                "allocationState": "deactivating",
+                "attachedState": "inactive",
+                "created": 1417563256000,
+                "data": {
+                    "fields": {
+                        "isHostPath": true
+                    }
+                },
+                "description": null,
+                "deviceNumber": -1,
+                "format": "docker",
+                "id": 9,
+                "image": null,
+                "imageId": null,
+                "instance": null,
+                "instanceId": null,
+                "kind": "volume",
+                "name": null,
+                "offering": null,
+                "offeringId": null,
+                "physicalSizeMb": null,
+                "removeTime": 1417563319000,
+                "removed": 1417563259000,
+                "state": "purging",
+                "storagePools": [
+                    {
+                        "accountId": 1,
+                        "agentId": 1,
+                        "created": 1417562939000,
+                        "data": {
+                            "fields": {
+                                "hostUuid": "7194b88c-b651-4884-942b-e0352c280e30",
+                                "type": "storagePool"
+                            }
+                        },
+                        "description": null,
+                        "external": false,
+                        "id": 1,
+                        "kind": "docker",
+                        "name": "boot2docker Storage Pool",
+                        "physicalTotalSizeMb": null,
+                        "removeTime": null,
+                        "removed": null,
+                        "state": "active",
+                        "type": "storagePool",
+                        "uuid": "7194b88c-b651-4884-942b-e0352c280e30-pool",
+                        "virtualTotalSizeMb": null,
+                        "zoneId": 1
+                    }
+                ],
+                "type": "volume",
+                "uri": "file:///mnt/sda1/tmp/baz2729060620224d1891a612ac4d00aa93",
+                "uuid": "2fa633bc-fcca-47d8-9985-5c056c50fda7",
+                "virtualSizeMb": null,
+                "zoneId": 1
+            },
+            "volumeId": 9
+        }
+    },
+    "id": "68fcddb5-a8a8-4b19-b1b3-00b60f83b5d1",
+    "name": "storage.volume.remove",
+    "previousIds": null,
+    "previousNames": null,
+    "publisher": null,
+    "replyTo": "reply.2609396891612625057",
+    "resourceId": "9",
+    "resourceType": "volumeStoragePoolMap",
+    "time": 1417563626981,
+    "timeoutMillis": 15000,
+    "transitioning": null,
+    "transitioningInternalMessage": null,
+    "transitioningMessage": null,
+    "transitioningProgress": null
+}

--- a/tests/docker/volume_purge_resp
+++ b/tests/docker/volume_purge_resp
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "volume": {
+            "format": "docker"
+        }
+    },
+    "name": "reply.2609396891612625057",
+    "previousIds": [
+        "68fcddb5-a8a8-4b19-b1b3-00b60f83b5d1"
+    ],
+    "previousNames": [
+        "storage.volume.remove"
+    ],
+    "resourceId": "9",
+    "resourceType": "volumeStoragePoolMap"
+}
+

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -470,3 +470,20 @@ def test_ping(agent, responses):
         resp['data']['resources'][1]['name'] = 'localhost Storage Pool'
 
     event_test(agent, 'docker/ping', post_func=post)
+
+@if_docker
+def test_volume_purge(agent, responses):
+    _delete_container('/c-c861f990-4472-4fa1-960f-65171b544c28')
+    _delete_container('/target_volumes_from')
+
+    client = docker_client()
+    c = client.create_container('ibuildthecloud/helloworld',
+                                volumes=['/volumes_from_path'],
+                                name='target_volumes_from')
+    client.start(c)
+    # TODO Figure out a better way to test this. Because purging a volume
+    # means removing it from disk, we run into trouble testing when
+    # boot2docker is in the picture because the locally running agent cannot
+    # see inside the b2d vm. We do currently test this functionality fully
+    # in the integration test suite.
+    event_test(agent, 'docker/volume_purge')


### PR DESCRIPTION
If a volume storage.volume.remove event reaches the agent,
perform the action of removing the volume from disk. However, if it is a
host mount, do not delete it.
