### PR TITLE
Check image labels for system container

### DIFF
--- a/tests/docker/ping_resp
+++ b/tests/docker/ping_resp
@@ -81,6 +81,23 @@
                 "image": "ibuildthecloud/helloworld:latest",
                 "systemContainer": null,
                 "labels": {"io.rancher.container.uuid": "uuid-stopped"}
+            },
+            {
+                "type" : "instance",
+                "uuid" : "uuid-system",
+                "state" : "stopped",
+                "image": "rancher/agent:v0.7.11",
+                "systemContainer": "rancher-agent",
+                "labels": {"io.rancher.container.uuid": "uuid-system"}
+            },
+            {
+                "type" : "instance",
+                "uuid" : "uuid-agent-instance",
+                "state" : "stopped",
+                "image": "rancher/agent-instance:v0.3.1",
+                "systemContainer": "networkAgent",
+                "labels": {"io.rancher.container.uuid": "uuid-agent-instance",
+                           "io.rancher.container.system": "networkAgent"}
             }
         ],
         "options" : {


### PR DESCRIPTION
Docker 1.8 does not return image labels as part of a container's
inspect, update logic to look at image labels in addtion to container
labels when determining if a container is a system container.