### PR TITLE
Support custom rancher images for air gap

### DIFF
--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -12,7 +12,8 @@ from docker.errors import APIError
 @pytest.fixture(scope='module')
 def pull_images():
     client = docker_client()
-    images = [('rancher/agent', 'v0.7.11'),
+    images = [('ibuildthecloud/helloworld', 'latest'),
+              ('rancher/agent', 'v0.7.11'),
               ('rancher/agent-instance', 'v0.3.1')]
     for i in images:
         client.pull(i[0], i[1])


### PR DESCRIPTION
Query docker on startup for images with the io.rancher.container.system
label and cache them so that ping logic can use them to determine if a
contianer is a system container.

This functionality is already tested under test_docker.py/test_ping