### PR TITLE
Introspect Docker for DockerRootDir for cAdvisor

### DIFF
--- a/cattle/__init__.py
+++ b/cattle/__init__.py
@@ -251,6 +251,11 @@ class Config:
         return default_value('CADVISOR_IP', '127.0.0.1')
 
     @staticmethod
+    def cadvisor_docker_root():
+        from cattle.plugins.docker import docker_client
+        return docker_client().info().get("DockerRootDir", None)
+
+    @staticmethod
     def host_api_ip():
         return default_value('HOST_API_IP', '0.0.0.0')
 

--- a/cattle/plugins/cadvisor/cadvisor.py
+++ b/cattle/plugins/cadvisor/cadvisor.py
@@ -12,6 +12,10 @@ class Cadvisor(object):
                '-listen_ip', Config.cadvisor_ip(),
                '-port', str(Config.cadvisor_port())]
 
+        docker_root = Config.cadvisor_docker_root()
+        if docker_root:
+            cmd += ["-docker_root", docker_root]
+
         wrapper = Config.cadvisor_wrapper()
 
         if len(wrapper):


### PR DESCRIPTION
Look at the docker graph storage area so that cAdvisor will work
when for non-default values.

Addresses issue rancher/rancher#2358