### PR TITLE
Add support for dynamic host labels

### DIFF
--- a/cattle/plugins/docker/compute.py
+++ b/cattle/plugins/docker/compute.py
@@ -215,6 +215,17 @@ class DockerCompute(KindBasedMixin, BaseComputeDriver):
             # Unknown. Assume running and state should sync up eventually.
             return 'running'
 
+    def _get_host_labels(self):
+        try:
+            labels = self.host_info.host_labels()
+        except:
+            log.exception("Error getting host labels")
+
+        if Config.labels():
+            labels.update(Config.labels())
+
+        return labels
+
     def _add_resources(self, ping, pong):
         if not utils.ping_include_resources(ping):
             return
@@ -232,7 +243,7 @@ class DockerCompute(KindBasedMixin, BaseComputeDriver):
             'type': 'host',
             'kind': 'docker',
             'name': Config.hostname(),
-            'labels': Config.labels(),
+            'labels': self._get_host_labels(),
             'physicalHostUuid': physical_host['uuid'],
             'uuid': DockerConfig.docker_uuid(),
             'info': stats

--- a/cattle/plugins/host_info/main.py
+++ b/cattle/plugins/host_info/main.py
@@ -28,3 +28,16 @@ class HostInfo(object):
                 data[collector.key_name()] = {}
 
         return data
+
+    def host_labels(self, label_pfx="io.rancher.host"):
+        labels = {}
+        for collector in self.collectors:
+            try:
+                get_labels = getattr(collector, "get_labels", None)
+                if callable(get_labels):
+                    labels.update(get_labels(label_pfx))
+            except:
+                log.exception(
+                    "Error getting {0} labels".format(collector.key_name()))
+
+        return labels if len(labels) > 0 else None

--- a/cattle/plugins/host_info/utils.py
+++ b/cattle/plugins/host_info/utils.py
@@ -1,0 +1,19 @@
+import re
+
+
+def semver_trunk(version, vrm_vals=3):
+        '''
+        vrm_vals: is a number representing the number of
+        digits to return. ex: 1.8.3
+          vmr_val = 1; return val 1
+          vmr_val = 2; return val 1.8
+          vmr_val = 3; return val 1.8.3
+        '''
+        if version:
+            return {
+                1: re.search('(\d+)', version).group(),
+                2: re.search('(\d+\.)?(\d+)', version).group(),
+                3: re.search('(\d+\.)?(\d+\.)?(\d+)', version).group(),
+            }.get(vrm_vals, version)
+
+        return version

--- a/tests/docker/ping_resp
+++ b/tests/docker/ping_resp
@@ -10,7 +10,10 @@
                 "name" : "localhost",
                 "physicalHostUuid" : "hostuuid",
                 "kind" : "docker",
-                "labels" : null,
+                "labels" : {
+                    "io.rancher.host.docker_version": "1.6",
+                    "io.rancher.host.linux_kernel_version": "4.1"
+                },
                 "info" : {
                     "cpuInfo": {
                         "count": 4,

--- a/tests/docker/ping_stat_exception_resp
+++ b/tests/docker/ping_stat_exception_resp
@@ -11,7 +11,10 @@
                 "physicalHostUuid" : "hostuuid",
                 "kind" : "docker",
                 "info" : null,
-                "labels" : null
+                "labels" : {
+                    "io.rancher.host.docker_version": "1.6",
+                    "io.rancher.host.linux_kernel_version": "4.1"
+                }
             },
             {
                 "type" : "storagePool",

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1071,10 +1071,16 @@ def assert_ping_stat_resources(resp):
 def ping_post_process(req, resp):
     resources = resp['data']['resources']
 
+    labels = {'io.rancher.host.docker_version': '1.6',
+              'io.rancher.host.linux_kernel_version': '4.1'}
+
     uuids = {'uuid-running': 0, 'uuid-stopped': 1, 'uuid-created': 2,
              'uuid-system': 3, 'uuid-sys-nover': 4, 'uuid-agent-instance': 5}
     instances = []
     for r in resources:
+        if r['type'] == 'host':
+            assert len(r['labels']) == 2
+            r['labels'] = labels
         if r['type'] == 'instance' and r['uuid'] in uuids:
             if r['uuid'] == 'uuid-running':
                 assert r['state'] == 'running'
@@ -1113,10 +1119,18 @@ def ping_post_process(req, resp):
 
 
 def ping_post_process_state_exception(req, resp):
+    labels = {'io.rancher.host.docker_version': '1.6',
+              'io.rancher.host.linux_kernel_version': '4.1'}
+
     # This filters down the returned resources to just the stat-based ones.
     # In other words, it gets rid of all containers from the response.
     resp['data']['resources'] = filter(lambda x: x.get('kind') == 'docker',
                                        resp['data']['resources'])
+    for r in resp['data']['resources']:
+        if r['type'] == 'host':
+            assert len(r['labels']) == 2
+            r['labels'] = labels
+
     assert_ping_stat_resources(resp)
 
 


### PR DESCRIPTION
This adds support to the host_info plugin to set labels for host attributes. Currently, Docker version is enabled.

When testing, the label is `io.rancher.host.docker_version: x.x` which will not show up in the UI. It has to be verified via the API.

