### PR TITLE
Inspect docker pool for device name

### DIFF
--- a/cattle/plugins/host_info/disk.py
+++ b/cattle/plugins/host_info/disk.py
@@ -34,7 +34,13 @@ class DiskCollector(object):
         include = True
 
         if self.docker_storage_driver == "devicemapper":
-            if device.startswith("/dev/mapper/docker-"):
+            pool = self._get_dockerstorage_info()
+
+            pool_name = pool.get("Pool Name", "/dev/mapper/docker-")
+            if pool_name.endswith("-pool"):
+                pool_name = pool_name[:-5]
+
+            if pool_name in device:
                 include = False
 
         return include

--- a/tests/test_host_info_plugin.py
+++ b/tests/test_host_info_plugin.py
@@ -237,7 +237,7 @@ def test_collect_data_diskinf(host_data):
     assert host_data['diskInfo']['mountPoints'].keys() == ['/dev/sda1']
 
     assert host_data['diskInfo']['fileSystems'].keys() > 0
-    assert not ("/dev/mapper/docker-8:1-523310-c3ae1852921c3fec9c9a74dce987f"
+    assert not ("/dev/mapper/docker-8:1-130861-c3ae1852921c3fec9c9a74dce987f"
                 "47f7e1ae8e7e3bcd9ad98e671f5d80a28d8") in \
         host_data['diskInfo']['fileSystems']
 


### PR DESCRIPTION
With DeviceMapper a pool is created with 100GB pool by default,
without this fix, the UI shows total disk space as Actual + Virtual.