### PR TITLE
Use 'auto' docker api version by default

### DIFF
--- a/cattle/plugins/docker/__init__.py
+++ b/cattle/plugins/docker/__init__.py
@@ -40,7 +40,7 @@ class DockerConfig:
 
     @staticmethod
     def api_version():
-        return default_value('DOCKER_API_VERSION', '1.18')
+        return default_value('DOCKER_API_VERSION', 'auto')
 
     @staticmethod
     def storage_api_version():


### PR DESCRIPTION
Use 'auto' docker api version as documented in http://docker-py.readthedocs.org/en/latest/api/#client-api.

Resolves partially rancher/rancher#3008
