### PR TITLE
Added new options for configuring cadvisor

### DIFF
--- a/cattle/__init__.py
+++ b/cattle/__init__.py
@@ -251,9 +251,17 @@ class Config:
         return default_value('CADVISOR_IP', '127.0.0.1')
 
     @staticmethod
+    def cadvisor_interval():
+        return default_value('CADVISOR_INTERVAL', '5s')
+
+    @staticmethod
     def cadvisor_docker_root():
         from cattle.plugins.docker import docker_client
         return docker_client().info().get("DockerRootDir", None)
+
+    @staticmethod
+    def cadvisor_opts():
+        return default_value('CADVISOR_OPTS', None)
 
     @staticmethod
     def host_api_ip():


### PR DESCRIPTION
This PR sets a new housekeeping interval to 5s to reduce
the load cAdvisor puts on a host. It also allows the user to
override that setting by adding CATTLE_CADVISOR_INTERVAL for
users that would like to really reduce its impact can set it to
very high values.

Also added, is a setting for `CATTLE_CADVISOR_OPTS` where users can
add options to the cAdvisor command line. This enables more control
for the user around how cAdvisor behaves. It also opens the door for
adding remote storage and metrics.

This will help with #3017