### PR TITLE
Dont delete volumes when deleting container

### DIFF
--- a/cattle/agent/handler.py
+++ b/cattle/agent/handler.py
@@ -105,8 +105,6 @@ class BaseHandler(object):
 class KindBasedMixin(object):
     CHECK_PATHS = [
         ["imageStoragePoolMap", "storagePool", "kind"],
-        ["volumeStoragePoolMap", "storagePool", "kind"],
-        ["snapshotStoragePoolMap", "storagePool", "kind"],
         ["instanceHostMap", "host", "kind"],
         ["instanceForceStop", "kind"],
         ["instanceInspect", "kind"],

--- a/cattle/plugins/docker/storage.py
+++ b/cattle/plugins/docker/storage.py
@@ -5,7 +5,6 @@ import requests
 from contextlib import closing
 from cattle.type_manager import get_type, MARSHALLER
 from cattle.storage import BaseStoragePool
-from cattle.agent.handler import KindBasedMixin
 from cattle.plugins.docker.util import is_no_op, remove_container
 from cattle.lock import lock
 from cattle.progress import Progress
@@ -16,9 +15,8 @@ from cattle.utils import is_str_set, JsonObject
 log = logging.getLogger('docker')
 
 
-class DockerPool(KindBasedMixin, BaseStoragePool):
+class DockerPool(BaseStoragePool):
     def __init__(self):
-        KindBasedMixin.__init__(self, kind='docker')
         BaseStoragePool.__init__(self)
 
     @staticmethod
@@ -293,6 +291,9 @@ class DockerPool(KindBasedMixin, BaseStoragePool):
 
             data = self._get_response_data(req, volumeStoragePoolMap)
             return self._reply(req, data)
+
+    def _check_supports(self, req):
+        return True
 
 
 class ImageValidationError(Exception):

--- a/cattle/plugins/docker/util.py
+++ b/cattle/plugins/docker/util.py
@@ -64,7 +64,7 @@ def is_no_op(resource):
 
 def remove_container(client, container):
     try:
-        client.remove_container(container, force=True, v=True)
+        client.remove_container(container, force=True)
     except APIError as e:
         try:
             if e.response.status_code != 404:


### PR DESCRIPTION
This changed does two things:
1. removes the `-v` ("delete volumes") option from our remove container command so that volume lifecycle can be handle explicitly on its own versus implicity by deleting a container
2. makes the docker storage driver support all volume events instead of just to volume events where the storagepool has a kind of 'docker'. This is because convoy storage pools have a kind of 'storagePool', not  'docker' but python-agent still needs to handle them.