### PR TITLE
Name container as r-{name} and not uuid

### DIFF
--- a/tests/docker/instance_activate_agent_instance_resp
+++ b/tests/docker/instance_activate_agent_instance_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -31,6 +31,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.agent_id": "5"
                         }
                     }

--- a/tests/docker/instance_activate_bridge_resp
+++ b/tests/docker/instance_activate_bridge_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -31,6 +31,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_command_args_resp
+++ b/tests/docker/instance_activate_command_args_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -30,7 +30,8 @@
                             }
                         ],
                         "Labels": {
-                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test"
                         }
                     }
                 }

--- a/tests/docker/instance_activate_command_null_resp
+++ b/tests/docker/instance_activate_command_null_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -30,7 +30,8 @@
                             }
                         ],
                         "Labels": {
-                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test"
                         }
                     }
                 }

--- a/tests/docker/instance_activate_command_resp
+++ b/tests/docker/instance_activate_command_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -30,7 +30,8 @@
                             }
                         ],
                         "Labels": {
-                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test"
                         }
                     }
                 }

--- a/tests/docker/instance_activate_double_links_resp
+++ b/tests/docker/instance_activate_double_links_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -31,6 +31,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_fields_resp
+++ b/tests/docker/instance_activate_fields_resp
@@ -14,7 +14,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -23,7 +23,8 @@
                             }
                         ],
                         "Labels": {
-                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test"
                         }
                     }
                 }

--- a/tests/docker/instance_activate_ipsec_lb_agent_resp
+++ b/tests/docker/instance_activate_ipsec_lb_agent_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -33,6 +33,7 @@
                             "io.rancher.container.agent_id": "42",
                             "io.rancher.container.system": "LoadBalancerAgent",
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_ipsec_network_agent_resp
+++ b/tests/docker/instance_activate_ipsec_network_agent_resp
@@ -17,7 +17,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -47,6 +47,7 @@
                             "io.rancher.container.agent_id": "42",
                             "io.rancher.container.system": "NetworkAgent",
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_ipsec_resp
+++ b/tests/docker/instance_activate_ipsec_resp
@@ -17,7 +17,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -46,6 +46,7 @@
                         "Labels": {
                             "io.rancher.container.agent_id": "42",
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_labels_resp
+++ b/tests/docker/instance_activate_labels_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -31,6 +31,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "constraint" : "label_key==bar",
                             "affinity" : "container==foo"
                         }

--- a/tests/docker/instance_activate_links_no_service_resp
+++ b/tests/docker/instance_activate_links_no_service_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -31,6 +31,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_links_resp
+++ b/tests/docker/instance_activate_links_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -31,6 +31,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_ports_resp
+++ b/tests/docker/instance_activate_ports_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -25,6 +25,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_pull_resp
+++ b/tests/docker/instance_activate_pull_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -31,6 +31,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_resp
+++ b/tests/docker/instance_activate_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -31,6 +31,7 @@
                         ],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }

--- a/tests/docker/instance_activate_volumes_resp
+++ b/tests/docker/instance_activate_volumes_resp
@@ -15,7 +15,7 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [
                             {
@@ -30,7 +30,8 @@
                             }
                         ],
                         "Labels": {
-                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28"
+                            "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test"
                         }
                     }
                 }

--- a/tests/docker/instance_deactivate_resp
+++ b/tests/docker/instance_deactivate_resp
@@ -12,11 +12,12 @@
                         "Labels": {},
                         "Image": "ibuildthecloud/helloworld:latest",
                         "Names": [
-                            "/c861f990-4472-4fa1-960f-65171b544c28"
+                            "/r-test"
                         ],
                         "Ports": [],
                         "Labels": {
                             "io.rancher.container.uuid": "c861f990-4472-4fa1-960f-65171b544c28",
+                            "io.rancher.container.name": "test",
                             "io.rancher.container.ip": "10.10.10.10/24"
                         }
                     }


### PR DESCRIPTION
We would ideally like to name containers what the user has specified but
there are concerns right now about /etc/hosts management that Docker
does overriding our DNS based stuff.  We have compromised right now in
naming containers r-{name}.  If we find the name is not unique or the
container name has invalid characters, we fall back to UUID for the
name.