### PR TITLE
Orphan volume on delete if we get a conflict

### DIFF
--- a/cattle/storage/__init__.py
+++ b/cattle/storage/__init__.py
@@ -63,7 +63,6 @@ class BaseStoragePool(BaseHandler):
 
         return self._do(
             req=req,
-            check=lambda: self._is_volume_removed(volume, storage_pool),
             result=lambda: self._get_response_data(req, volumeStoragePoolMap),
             lock_obj=volume,
             action=lambda: self._do_volume_remove(volume, storage_pool,

--- a/tests/docker_common.py
+++ b/tests/docker_common.py
@@ -12,6 +12,7 @@ import pytest
 from cattle import CONFIG_OVERRIDE, Config
 from .common_fixtures import TEST_DIR
 from docker.utils import compare_version
+from cattle.plugins.docker import DockerConfig
 
 CONFIG_OVERRIDE['DOCKER_REQUIRED'] = 'false'  # NOQA
 CONFIG_OVERRIDE['DOCKER_HOST_IP'] = '1.2.3.4'  # NOQA
@@ -123,6 +124,14 @@ def remove_state_file(container):
                 os.remove(file_path)
         except:
             pass
+
+
+def delete_volume(name):
+    client = docker_client(version=DockerConfig.storage_api_version())
+    try:
+        client.remove_volume(name)
+    except:
+        pass
 
 
 def delete_container(name):


### PR DESCRIPTION
This addresses a common problem we've seen in docker 1.10 where
docker's volume ref count becomes inaccurate and docker thinks a volume
is in use by a container when it actually isn't. When this scenario
arises, the volume will get stuck in a purging state in cattle. To
avoid this, we are going to log and ignore 409 errors that arise when
removing a volume.