### PR TITLE
Added python 2.7.11 to the build process

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ subprocess32
 psutil
 arrow
 ndg-httpsclient
-requests==2.7.0
+requests==2.9.1
 websocket-client==0.32.0

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -4,11 +4,22 @@ set -e
 cd $(dirname $0)/..
 
 apt-get update
-apt-get install -y arptables python-pip python-dev rsync libssl-dev libffi-dev uuid-runtime
+apt-get install -y arptables rsync libssl-dev libffi-dev uuid-runtime
 
+if [ ! -e /opt/python/2.7.11 ]; then
 
-curl https://bootstrap.pypa.io/get-pip.py | python
-pip install tox psutil subprocess32 ndg-httpsclient
+    mkdir -p /opt/python/2.7.11
+    curl https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz | tar -zxv -C /tmp/
+
+    pushd /tmp/Python-2.7.11/
+    ./configure --prefix=/opt/python/2.7.11
+    make
+    make install
+
+    popd
+fi
+curl https://bootstrap.pypa.io/get-pip.py | /opt/python/2.7.11/bin/python
+/opt/python/2.7.11/bin/pip install tox psutil subprocess32 ndg-httpsclient
 
 if [ ! -x "$(which nsenter)" ]; then
     TMP=$(mktemp -d)

--- a/scripts/build
+++ b/scripts/build
@@ -29,6 +29,7 @@ python_deps()
 }
 
 cd $(dirname $0)/..
+. scripts/common
 
 python_deps
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -2,6 +2,7 @@
 set -e
 
 cd $(dirname $0)
+. common
 
 ./clean
 ./bootstrap

--- a/scripts/common
+++ b/scripts/common
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DEFAULT_PYTHON=/opt/python/2.7.11
+
+if [ -e ${DEFAULT_PYTHON} ]; then
+  export PATH=${DEFAULT_PYTHON}/bin:${PATH}
+fi

--- a/scripts/package
+++ b/scripts/package
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 cd $(dirname $0)/..
+. scripts/common
 
 CONTENT=$(uuidgen)
 

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,7 @@
 set -e
 
 cd $(dirname $0)/..
+. scripts/common
 
 if [ -x "$(which wrapdocker)" ]; then
     wrapdocker > /tmp/docker.log 2>&1
@@ -20,8 +21,9 @@ trap "rm -rf $TMP" exit
 rsync -a --exclude .tox ./ $TMP
 pushd $TMP
 
-sudo env DOCKER_TEST=true tox -e flake8
-sudo env DOCKER_TEST=true tox -e py27
+echo $PATH
+DOCKER_TEST=true tox -e flake8
+DOCKER_TEST=true tox -e py27
 
 popd
 rsync -a --delete $TMP/.tox/ .tox


### PR DESCRIPTION
The purpose of this PR is to match the version of python that will be added to the rancher/agent image.

Building python 2.7.11 from source and installing it out of the way of the system python. It checks to see if its there on subsequent runs.

Also bumped up requests to match what is running in the Agent image version. 

