### PR TITLE
allow shared/slave flags for docker volumes

### DIFF
--- a/cattle/plugins/docker/compute.py
+++ b/cattle/plugins/docker/compute.py
@@ -699,8 +699,11 @@ class DockerCompute(KindBasedMixin, BaseComputeDriver):
                     if len(parts) == 1:
                         volumes_map[parts[0]] = {}
                     else:
-                        read_only = len(parts) == 3 and parts[2] == 'ro'
-                        bind = {'bind': parts[1], 'ro': read_only}
+                        if len(parts) == 3:
+                            mode = parts[2]
+                        else:
+                            mode = 'rw'
+                        bind = {'bind': parts[1], 'mode': mode}
                         binds_map[parts[0]] = bind
                 create_config['volumes'] = volumes_map
                 start_config['binds'] = binds_map

--- a/tests/docker/instance_activate_volumes
+++ b/tests/docker/instance_activate_volumes
@@ -29,7 +29,7 @@
                         "imageUuid": "docker:ibuildthecloud/helloworld",
                         "command": "sleep 5",
                         "publishAllPorts": true,
-                        "dataVolumes": ["/proc:/host/proc", "/sys:/host/sys:ro", "/random"],
+                        "dataVolumes": ["/proc:/host/proc", "/sys:/host/sys:ro", "/random", "/slave_test:/slave_test:Z"],
                         "startOnCreate": true
                     }
                 },

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1191,7 +1191,7 @@ def test_instance_activate_volumes(agent, responses):
         assert inspect['Volumes']['/volumes_from_path_by_uuid'] is not None
         assert inspect['Volumes']['/volumes_from_path_by_id'] is not None
 
-        assert len(inspect['Volumes']) == 5
+        assert len(inspect['Volumes']) == 6
 
         assert inspect['VolumesRW'] == {
             '/host/proc': True,
@@ -1199,10 +1199,12 @@ def test_instance_activate_volumes(agent, responses):
             '/random': True,
             '/volumes_from_path_by_uuid': True,
             '/volumes_from_path_by_id': True,
-
+            '/slave_test': True,
         }
 
-        assert set(['/sys:/host/sys:ro', '/proc:/host/proc:rw']) == set(
+        assert set(['/sys:/host/sys:ro',
+                    '/proc:/host/proc:rw',
+                    '/slave_test:/slave_test:Z']) == set(
             inspect['HostConfig']['Binds'])
 
         instance_activate_common_validation(resp)


### PR DESCRIPTION
@cjellick - This allows passing in mount flags other than `rw` and `ro`