### PR TITLE
use fqdn instead of hostname

### DIFF
--- a/cattle/__init__.py
+++ b/cattle/__init__.py
@@ -97,7 +97,7 @@ class Config:
 
     @staticmethod
     def hostname():
-        return default_value('HOSTNAME', socket.gethostname())
+        return default_value('HOSTNAME', socket.getfqdn())
 
     @staticmethod
     def workers():


### PR DESCRIPTION
@ibuildthecloud - This is required to fix kubernetes ebs volume behavior. 
